### PR TITLE
Fix iOS6 scroll height bug

### DIFF
--- a/lib/jquery.mobile.iscrollview.js
+++ b/lib/jquery.mobile.iscrollview.js
@@ -1423,6 +1423,7 @@ dependency:  iScroll 4.1.9 https://github.com/cubiq/iscroll or later (4.2 provid
   _create_iscroll_object: function() {
     /*jslint newcap:true */
     this.iscroll = new IScroll(this, this.$wrapper.get(0), this._create_iscroll_options());
+    window.iscroll = this.iscroll;
     /* jslint newcap:false */
     },
 
@@ -1849,7 +1850,11 @@ jQuery(document).bind("pagecreate", function (e) {
   // _create() function for each member of the array.
   // If the array is of zero length, then no _create() fucntion is called.
   var elements = jQuery(e.target).find(":jqmData(iscroll)");
-    elements.iscrollview();
-  });
+  elements.iscrollview();
+});
+
+jQuery(document).live('pageshow', function(e) {
+  if (window.iscroll) window.iscroll.refresh();
+});
 
 


### PR DESCRIPTION
in iOS6 scroll element height is detected incorrectly
added refresh on page show to restore the correct height.
