### PR TITLE
Resolves #58. Fix perma-rotation of arrow icon after first pull-to-refresh action on both iOS and Android.

### DIFF
--- a/lib/jquery.mobile.iscrollview-pull.css
+++ b/lib/jquery.mobile.iscrollview-pull.css
@@ -40,6 +40,10 @@
   -moz-transition: -moz-transform 250ms linear;  
   -o-transition: -o-transform 250ms linear;   
   transition: transform 250ms linear;   
+  -webkit-animation: none;
+  -moz-animation: none;
+  -o-animation: none;
+  animation: none;
 }
 
 /* Note that translateZ(0) triggers hardware acceleration on WebKit browsers 
@@ -48,8 +52,12 @@
 .iscroll-pulldown .iscroll-pull-icon {
   -webkit-transform: rotate(0deg) translateZ(0);
   -moz-transform: rotate(0deg);
-  -o-transform: rotate(0deg);  
-  transform: rotate(0deg) translateZ(0);      
+  -o-transform: rotate(0deg);
+  transform: rotate(0deg) translateZ(0);
+  -webkit-animation: none;
+  -moz-animation: none;
+  -o-animation: none;
+  animation: none;
 }
 
 .iscroll-pullup .iscroll-pull-icon  {
@@ -57,13 +65,21 @@
   -moz-transform: rotate(-180deg);
   -o-transform: rotate(-180deg);  
   transform: rotate(-180deg) translateZ(0);  
+  -webkit-animation: none;
+  -moz-animation: none;
+  -o-animation: none;
+  animation: none;
 }
 
 .iscroll-pulldown.iscroll-pull-pulled .iscroll-pull-icon {
   -webkit-transform: rotate(-180deg) translateZ(0);
   -moz-transform: rotate(-180deg);
   -o-transform: rotate(-180deg);  
-  transform: rotate(-180deg) translateZ(0);  
+  transform: rotate(-180deg) translateZ(0);
+  -webkit-animation: none;
+  -moz-animation: none;
+  -o-animation: none;
+  animation: none;
 }
 
 .iscroll-pullup.iscroll-pull-pulled .iscroll-pull-icon {
@@ -109,4 +125,3 @@
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 } 
-

--- a/lib/jquery.mobile.iscrollview.js
+++ b/lib/jquery.mobile.iscrollview.js
@@ -1718,6 +1718,8 @@ dependency:  iScroll 4.1.9 https://github.com/cubiq/iscroll or later (4.2 provid
       if ($pull.is("." + this.options.pullLoadingClass + ", ." + this.options.pullPulledClass)) {
         $pull.removeClass(this.options.pullPulledClass + " " + this.options.pullLoadingClass);
         this._replacePullText($pull, text);
+        //force animations to stop on iOS, which doesn't seem to want to give up. Stubborn bugger.
+        $(".iscroll-pull-icon", $pull).replaceWith( $('<span class="iscroll-pull-icon"></span>') );
         }
       },
 


### PR DESCRIPTION
Not 100% positive this is perfect, but it works perfectly in my use-case. Does it need to support initial content, or additional class names, for the span it's replacing? If so, what would be the best way to do so?
