### PR TITLE
OnPageRefresh issue with JQM + BackboneJS Views

### DIFF
--- a/lib/jquery.mobile.iscrollview.js
+++ b/lib/jquery.mobile.iscrollview.js
@@ -1402,7 +1402,7 @@ dependency:  iScroll 4.1.9 https://github.com/cubiq/iscroll or later (4.2 provid
        hidden = _this._setPageVisible();
         if (_callbackBefore) { _callbackBefore(); }
       _this._triggerWidget("onbeforerefresh");
-      _this.iscroll.refresh();
+      if(_this.iscroll) { _this.iscroll.refresh(); }
       _this._triggerWidget("onafterrefresh");
         if (_callbackAfter) { _callbackAfter(); }
       _this._restorePageVisibility(hidden);


### PR DESCRIPTION
I´m using jquery-mobile-iscrollview together with backbone.js views + jquerymobile. When I navigate from one view to the other. I get the following error:

```
Uncaught TypeError: Cannot call method 'refresh' of null head.file-jquery_mobile_iscrollview_js_c226280c50.js:1405
(anonymous function)
```

To test for the iscroll instance solved that problem for me.
