### PR TITLE
Fix `topSpacerClass is undefined` error in `_undoAddSpacers`

### DIFF
--- a/lib/jquery.mobile.iscrollview.js
+++ b/lib/jquery.mobile.iscrollview.js
@@ -1512,8 +1512,8 @@ function jqmIscrollviewRemoveLayerXYProps(e) {
   },
 
   _undoAddSpacers: function() {
-    this.$wrapper.find(topSpacerClass).remove();
-    this.$wrapper.find(bottomSpacerClass).remove();
+    this.$wrapper.find(this.options.topSpacerClass).remove();
+    this.$wrapper.find(this.options.bottomSpacerClass).remove();
 
   },
 


### PR DESCRIPTION
Fixed a `topSpacerClass is undefined` error, that was being thrown when using the `destroy` method.
